### PR TITLE
Added restart functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ USER venting
 
 EXPOSE 8080
 
+ENV DOCKER_TIMEOUT=10
+
 COPY --from=builder /bin/silo-agent /bin/silo-agent
 
 CMD [ "/bin/silo-agent" ]

--- a/config/config.go
+++ b/config/config.go
@@ -1,20 +1,37 @@
 package config
 
 import (
+	"os"
+	"strconv"
+	"time"
+
 	cfg "github.com/infinityworks/go-common/config"
 )
 
 // Config - Defines application configuration
 type Config struct {
 	*cfg.BaseConfig
+	DockerTimeout *time.Duration
 }
 
 // Init - Initialises Config struct with safe defaults if not present
 func Init() Config {
 	ac := cfg.Init()
 
+	var timeout time.Duration = 5
+
+	if os.Getenv("DOCKER_TIMEOUT") != "" {
+		envTimeout, err := strconv.Atoi(os.Getenv("DOCKER_TIMEOUT"))
+		if err != nil {
+			println("Error converting env variable DOCKER_TIMEOUT to int")
+		}
+
+		timeout = time.Duration(envTimeout)
+	}
+
 	appConfig := Config{
 		&ac,
+		&timeout,
 	}
 
 	return appConfig

--- a/docker/container.go
+++ b/docker/container.go
@@ -3,19 +3,21 @@ package docker
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 )
 
-// ListContainers returns the effective output of a `docker ps -a`
+// ListContainers returns a list of containers on the local system
 func ListContainers() ([]types.Container, error) {
+
 	cli, err := client.NewEnvClient()
 	if err != nil {
 		return nil, fmt.Errorf("Error creating Docker client: %v", err)
 	}
 
-	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{})
+	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{All: true})
 	if err != nil {
 		return containers, fmt.Errorf("Error listing containers: %v", err)
 	}
@@ -25,4 +27,21 @@ func ListContainers() ([]types.Container, error) {
 	}
 
 	return containers, nil
+}
+
+// RestartContainer issues a restart command to docker for the specified container
+func RestartContainer(id string, timeout *time.Duration) error {
+
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return fmt.Errorf("Error creating Docker client: %v", err)
+	}
+
+	err = cli.ContainerRestart(context.Background(), id, timeout)
+
+	if err != nil {
+		return fmt.Errorf("Error restarting container %s, error: %v", id, err)
+	}
+
+	return nil
 }

--- a/docker/container.go
+++ b/docker/container.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"github.com/pkg/errors"
 )
 
 // ListContainers returns a list of containers on the local system
@@ -40,7 +41,7 @@ func RestartContainer(id string, timeout *time.Duration) error {
 	err = cli.ContainerRestart(context.Background(), id, timeout)
 
 	if err != nil {
-		return fmt.Errorf("Error restarting container %s, error: %v", id, err)
+		return errors.Wrapf(err, "Error restarting container %s", id)
 	}
 
 	return nil

--- a/http/controllers.go
+++ b/http/controllers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/gorilla/mux"
 	"github.com/infinityworks/go-common/router"
 	"github.com/venting/silo/docker"
 )
@@ -19,6 +20,22 @@ func (h Handler) ListContainers(w http.ResponseWriter, r *http.Request) (status 
 	}
 
 	return router.MarshalBody(cs)
+}
+
+// RestartContainer will query the local docker socket, and return a list of containers that are currently running
+// it will also attempt to represent other information (like uptime and history) in an ordered manner
+func (h Handler) RestartContainer(w http.ResponseWriter, r *http.Request) (status int, body []byte, err error) {
+
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	err = docker.RestartContainer(id, h.Config.DockerTimeout)
+
+	if err != nil {
+		return http.StatusInternalServerError, []byte(""), err
+	}
+
+	return http.StatusOK, []byte(""), nil
 }
 
 // SetConfig method will accept an incoming configuration change, it will take the body of the request, and use that

--- a/http/routes.go
+++ b/http/routes.go
@@ -26,7 +26,7 @@ func (h Handler) CreateRoutes() router.Routes {
 		router.Route{
 			Name:        "RestartContainer",
 			Method:      "POST",
-			Pattern:     "/container/restart/{id}",
+			Pattern:     "/container/{id}/restart",
 			HandlerFunc: h.RestartContainer,
 		},
 

--- a/http/routes.go
+++ b/http/routes.go
@@ -22,6 +22,14 @@ func (h Handler) CreateRoutes() router.Routes {
 			HandlerFunc: h.ListContainers,
 		},
 
+		// Restarts the container with the specified ID
+		router.Route{
+			Name:        "RestartContainer",
+			Method:      "POST",
+			Pattern:     "/container/restart/{id}",
+			HandlerFunc: h.RestartContainer,
+		},
+
 		// SetConfig route exposes the basic interface that allows configuration to be updated
 		router.Route{
 			Name:        "SetConfig",


### PR DESCRIPTION
Added the ability to restart a container through the API by the container `id` as reported by Docker.
This is the start of us having some ad-hoc control outside a configuration deployment.